### PR TITLE
add http proxy support

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -54,13 +54,14 @@ export async function calculateActualConfig(config: FileSystemConfig): Promise<F
         break;
       case 1:
       case 2:
-        if (!session.proxyhost) throw new Error(`Proxymethod is SOCKS 4/5 but 'proxyhost' is missing`);
+      case 3:
+        if (!session.proxyhost) throw new Error(`Proxymethod is SOCKS 4/5 or HTTP but 'proxyhost' is missing`);
         config.proxy = {
           host: session.proxyhost,
           port: session.proxyport,
-          type: session.proxymethod === 1 ? 'socks4' : 'socks5',
+          type: session.proxymethod === 1 ? 'socks4' : (session.proxymethod === 2 ? 'socks5' : 'http'),
         };
-        break;
+      break;
       default:
         throw new Error(`The requested PuTTY session uses an unsupported proxy method`);
     }
@@ -135,6 +136,8 @@ export async function createSocket(config: FileSystemConfig): Promise<NodeJS.Rea
     case 'socks4':
     case 'socks5':
       return await proxy.socks(config);
+    case 'http':
+      return await proxy.http(config);
     default:
       throw new Error(`Unknown proxy method`);
   }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -17,7 +17,7 @@ async function assertFs(man: Manager, uri: vscode.Uri) {
 }
 
 export interface ProxyConfig {
-  type: 'socks4' | 'socks5';
+  type: 'socks4' | 'socks5' | 'http';
   host: string;
   port: number;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,20 +1,25 @@
 
 import * as dns from 'dns';
+import { request } from 'http';
 import { SocksClient } from 'socks';
 import { FileSystemConfig } from './manager';
 import { toPromise } from './toPromise';
 
-export async function socks(config: FileSystemConfig): Promise<NodeJS.ReadableStream> {
+function validateConfig(config: FileSystemConfig) {
   if (!config.proxy) throw new Error(`Missing field 'config.proxy'`);
   if (!config.proxy.host) throw new Error(`Missing field 'config.proxy.host'`);
   if (!config.proxy.port) throw new Error(`Missing field 'config.proxy.port'`);
   if (!config.proxy.type) throw new Error(`Missing field 'config.proxy.type'`);
-  if (config.proxy.type !== 'socks4' && config.proxy.type !== 'socks5') {
-    throw new Error(`Expected config.proxy.type' to be 'socks4 or 'socks5'`);
+}
+
+export async function socks(config: FileSystemConfig): Promise<NodeJS.ReadableStream> {
+  validateConfig(config);
+  if (config.proxy!.type !== 'socks4' && config.proxy!.type !== 'socks5') {
+    throw new Error(`Expected 'config.proxy.type' to be 'socks4' or 'socks5'`);
   }
   try {
     const ipaddress = (await toPromise<string[]>(cb => dns.resolve(config.proxy!.host, cb)))[0];
-    if (!ipaddress) throw new Error(`Couldn't resolve '${config.proxy.host}'`);
+    if (!ipaddress) throw new Error(`Couldn't resolve '${config.proxy!.host}'`);
     const con = await SocksClient.createConnection({
       command: 'connect',
       destination: {
@@ -23,12 +28,35 @@ export async function socks(config: FileSystemConfig): Promise<NodeJS.ReadableSt
       },
       proxy: {
         ipaddress,
-        port: config.proxy.port,
-        type: config.proxy.type === 'socks4' ? 4 : 5,
+        port: config.proxy!.port,
+        type: config.proxy!.type === 'socks4' ? 4 : 5,
       },
     });
     return con.socket as NodeJS.ReadableStream;
   } catch (e) {
     throw new Error(`Error while connecting to the the proxy: ${e.message}`);
   }
+}
+
+export function http(config: FileSystemConfig): Promise<NodeJS.ReadableStream> {
+  validateConfig(config);
+  return new Promise<NodeJS.ReadableStream>((resolve, reject) => {
+    if (config.proxy!.type !== 'http') {
+      reject(new Error(`Expected config.proxy.type' to be 'http'`));
+    }
+    try {
+      let req = request({
+        port: config.proxy!.port,
+        hostname: config.proxy!.host,
+        method: 'CONNECT',
+        path: `${config.host}:${config.port}`
+      })
+      req.end();
+      req.on('connect', (res, socket) => {
+        resolve(socket as NodeJS.ReadableStream);
+      });
+    } catch (e) {
+      reject(new Error(`Error while connecting to the the proxy: ${e.message}`));
+    }
+  });
 }


### PR DESCRIPTION
This adds support for tunneling ssh through an http proxy. It consumes the configuration from putty correctly as well.

The tunneling uses node's built in http library and the HTTP CONNECT method.