### PR TITLE
extract username from putty hostname if not set

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -41,6 +41,9 @@ export async function calculateActualConfig(config: FileSystemConfig): Promise<F
     if (!session) throw new Error(`Couldn't find the requested PuTTY session`);
     if (session.protocol !== 'ssh') throw new Error(`The requested PuTTY session isn't a SSH session`);
     config.username = config.username || session.username;
+    if (!config.username && session.hostname && session.hostname.indexOf('@') >= 1) {
+      config.username = session.hostname.substr(0, session.hostname.indexOf('@'));
+    }
     config.host = config.host || session.hostname;
     config.port = session.portnumber || config.port;
     config.agent = config.agent || (session.tryagent ? 'pageant' : undefined);


### PR DESCRIPTION
This extracts the username from the putty hostname string (it can be added there as `username@hostname`) to avoid the username dialog.
It checks if the username is set in a different way already, then checks if the hostname contains an `@` and then uses everything in front of the `@` as the username.