### PR TITLE
Add option.detail with config.name

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ async function pickConfig(manager: Manager, activeOrNot?: boolean) {
   if (activeOrNot === false) {
     names = others.filter(c => !names.find(cc => cc.name === c.name));
   } else if (activeOrNot === undefined) {
-    others.forEach(n => names.indexOf(n) === -1 && names.push(n));
+    names = others;
   }
   const options: vscode.QuickPickItem[] = names.map(config => ({
     label: config.label || config.username + '@' + config.host,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,8 +12,9 @@ async function pickConfig(manager: Manager, activeOrNot?: boolean) {
     others.forEach(n => names.indexOf(n) === -1 && names.push(n));
   }
   const options: vscode.QuickPickItem[] = names.map(config => ({
-    label: config.label || config.name,
-    description: config.label && config.name,
+    label: config.label || config.username + '@' + config.host,
+    description: config.root,
+    detail: config.name
   }));
   const pick = await vscode.window.showQuickPick(options, { placeHolder: 'SSH FS Configuration' });
   return pick && pick.detail;


### PR DESCRIPTION
Missing detail in option, so config name never returned. Fixes #94 
Restruct QuickPick options for optional parameter:  config.label, config.root

Fixes #95 
Indexof with array of object not working so easy. From the other side, showing active configs before all other configs can confuse. I would like to have same config order all the time. Less is more.