### PR TITLE
Implement file index provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -430,6 +430,7 @@
         "vscode": "^1.1.21"
     },
     "dependencies": {
+        "binary-split": "^1.0.5",
         "jsonc-parser": "^2.0.0",
         "socks": "^2.2.0",
         "ssh2": "^0.6.0",

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -31,7 +31,7 @@ export async function calculateActualConfig(config: FileSystemConfig): Promise<F
   config.host = replaceVariables(config.host);
   const port = replaceVariables((config.port || '') + '');
   if (port) config.port = Number(port);
-  config.agent = replaceVariables(config.agent);
+  config.agent = replaceVariables(config.agent) || process.env.SSH_AUTH_SOCK;
   config.privateKeyPath = replaceVariables(config.privateKeyPath);
   if (config.putty) {
     let nameOnly = true;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
     subscribe(vscode.commands.registerCommand(command, callback, thisArg));
 
   subscribe(vscode.workspace.registerFileSystemProvider('ssh', manager, { isCaseSensitive: true }));
+  subscribe(vscode.workspace.registerFileIndexProvider('ssh', manager));
 
   async function pickAndClick(func: (name: string) => void, name?: string, activeOrNot?: boolean) {
     name = name || await pickConfig(manager, activeOrNot);


### PR DESCRIPTION
This powers VSCode's built-in fuzzy file finder.

The approach taken is to execute `find` on the remote machine. This is more efficient than the implementation on the insiders branch, which uses SFTP.

This implements part of #2. I'm not actually proposing that this be merged yet, since sadly the file finding APIs are still experimental.