### PR TITLE
[Fix] Set default port same as placeholder, instead of undefined

### DIFF
--- a/webview/src/ConfigEditor/fields.tsx
+++ b/webview/src/ConfigEditor/fields.tsx
@@ -60,7 +60,7 @@ export function host(config: FileSystemConfig, onChange: FSCChanged<'host'>): Re
 }
 
 export function port(config: FileSystemConfig, onChange: FSCChanged<'port'>): React.ReactElement {
-  const callback = (value: number) => onChange('port', value === 22 ? undefined : value);
+  const callback = (value: number) => onChange('port', value);
   const description = 'Port number of the server. Supports environment variables, e.g. $PORT';
   return <FieldNumber key="port" label="Port" value={config.port} onChange={callback} optional={true} description={description} />
 }


### PR DESCRIPTION
This patch fixes a bug when connecting behind http proxy, the config port will be undefined so that the connection stuck.

```typescript
    try {
      Logging.debug(`\tConnecting to ${config.host}:${config.port} over http proxy at ${config.proxy!.host}:${config.proxy!.port}`);
      const req = request({
        port: config.proxy!.port,
        hostname: config.proxy!.host,
        method: 'CONNECT',
        path: `${config.host}:${config.port}`,  // here is the bug source
      });
      req.end();
      req.on('connect', (res, socket) => {
        resolve(socket as NodeJS.ReadableStream);
      });
    } catch (e) {
      reject(new Error(`Error while connecting to the the proxy: ${e.message}`));
    }
```