### PR TITLE
Remote Debugging without extra local launch settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ This extension makes use of the new FileSystemProvider, added in version 1.23.0 
 * Easily create configurations that reference a PuTTY session/configuration
 * Have multiple SSH (and regular) workspace folders at once
 * Make use of SOCKS 4/5 and HTTP proxies and connection hopping
+* Remote Debugging
 * Support for OpenVMS versioning filesystem
+* Easily open a SSH Terminal on VSCode
 
 ## Usage
 Use the command `SSH FS: Create a SSH FS configuration`, or open the Settings UI using the `SSH FS: Open settings and edit configurations` and click Add:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This extension makes use of the new FileSystemProvider, added in version 1.23.0 
 * Easily create configurations that reference a PuTTY session/configuration
 * Have multiple SSH (and regular) workspace folders at once
 * Make use of SOCKS 4/5 and HTTP proxies and connection hopping
+* Support for OpenVMS versioning filesystem
 
 ## Usage
 Use the command `SSH FS: Create a SSH FS configuration`, or open the Settings UI using the `SSH FS: Open settings and edit configurations` and click Add:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "onCommand:sshfs.disconnect",
         "onCommand:sshfs.configure",
         "onCommand:sshfs.reload",
-        "onCommand:sshfs.settings"
+        "onCommand:sshfs.settings",
+        "onCommand:sshfs.connectTerminal"
     ],
     "main": "./dist/extension.js",
     "author": {
@@ -81,6 +82,11 @@
                 "command": "sshfs.settings",
                 "title": "Open settings and edit configurations",
                 "category": "SSH FS"
+            },
+            {
+                "command": "sshfs.connectTerminal",
+                "title": "Connect SSH Terminal",
+                "category": "SSH FS"
             }
         ],
         "menus": {
@@ -112,6 +118,10 @@
                 {
                     "command": "sshfs.settings",
                     "group": "SSH FS@7"
+                },
+                {
+                    "command": "sshfs.connectTerminal",
+                    "group": "SSH FS@8"
                 }
             ],
             "view/item/context": [
@@ -144,6 +154,11 @@
                     "command": "sshfs.settings",
                     "when": "view == 'sshfs-configs' && !viewItem",
                     "group": "SSH FS@6"
+                },
+                {
+                    "command": "sshfs.connectTerminal",
+                    "when": "view == 'sshfs-configs' && viewItem",
+                    "group": "SSH FS@7"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-sshfs",
     "displayName": "SSH FS",
     "description": "File system provider using SSH",
-    "publisher": "Kelvin",
+    "publisher": "vistec",
     "version": "1.16.2",
     "engines": {
         "vscode": "^1.33.0"

--- a/src/connectTerminal.ts
+++ b/src/connectTerminal.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+import { loadConfigs } from './config';
+import { calculateActualConfig } from './connect';
+
+export async function openTerminal(name: string) {
+    var connectionMethod = "password";
+    const all = await loadConfigs();
+    var config = all.find(c => c.name === name);
+    if (!config) {
+      throw new Error(`A SSH filesystem with the name '${name}' doesn't exist`);
+    }
+    config = (await calculateActualConfig(config))!;
+
+    var ssh = 'ssh ' + config.host + ' -l ' + config.username;
+    if (config.port !== 22 && config.port !== undefined && config.port) 
+      ssh += ' -p ' + config.port;
+    // Add to be private key path because of vulnerability leak we can't pass private key by command
+    if (config.privateKeyPath !== undefined && config.privateKeyPath) {
+        connectionMethod = "privateKey";
+        ssh += ' -i ' + config.privateKeyPath; 
+    }
+    if (config.agent !== undefined && config.agent) 
+      connectionMethod = "agent";
+    var terminal = vscode.window.createTerminal(config.label || config.name);
+    terminal.sendText(ssh);
+    
+    if (config.password && connectionMethod === "password") 
+      setTimeout( () => {
+         if (config &&  config.password)
+          terminal.sendText(config.password) 
+        }, 1000);
+
+    var time = 1000;
+    if (config.customTerminalCommands !== undefined && config.customTerminalCommands)            
+            config.customTerminalCommands.forEach(element => {
+                time = time + 1000;
+                setTimeout(() => {terminal.sendText(element)},time);    
+            });   
+
+    terminal.show();
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,6 +67,7 @@ export function activate(context: vscode.ExtensionContext) {
   registerCommand('sshfs.disconnect', (name?: string) => pickAndClick(manager.commandDisconnect, name, true));
   registerCommand('sshfs.reconnect', (name?: string) => pickAndClick(manager.commandReconnect, name, true));
   registerCommand('sshfs.configure', (name?: string) => pickAndClick(manager.commandConfigure, name));
+  registerCommand('sshfs.connectTerminal', (name?: string) => pickAndClick(manager.commandConnectTerminal, name));
 
   registerCommand('sshfs.reload', loadConfigs);
 }

--- a/src/fileSystemConfig.ts
+++ b/src/fileSystemConfig.ts
@@ -84,7 +84,9 @@ export interface FileSystemConfig extends ConnectConfig {
   merge?: boolean;
   /** Path on the remote server where the root path in vscode should point to. Defaults to / */
   root?: string;
-  /** A name of a PuTTY session, or `true` to find the PuTTY session from the host address  */
+  /** Filesystem is on OpenVSM with versioning, Set if not init and root starts with '/DISK$' */
+  openvms?: boolean;
+  /** A name of a PuTTY session, or `true` to find the PuTTY session from the host address  */  
   putty?: string | boolean;
   /** Optional object defining a proxy to use */
   proxy?: ProxyConfig;

--- a/src/fileSystemConfig.ts
+++ b/src/fileSystemConfig.ts
@@ -102,9 +102,9 @@ export interface FileSystemConfig extends ConnectConfig {
   _location?: ConfigLocation;
   /** Internal property keeping track of where this config comes from (including merges) */
   _locations: ConfigLocation[];
-  /* Debug port to attach */
+  /** Debug port to attach */
   debugPort?: number;
-  /* Task to run before debug session starts. SSH command: e.g. `/opt/vistec/python/bin/python -m ptvsd --host ${config.host} --port ${config.debugPort} --wait ${file}` */
+  /** Task to run before debug session starts. SSH command: e.g. `/opt/vistec/python/bin/python -m ptvsd --host ${config.host} --port ${config.debugPort} --wait ${file}` */
   debugPreLaunch?: string;
 }
 

--- a/src/fileSystemConfig.ts
+++ b/src/fileSystemConfig.ts
@@ -70,6 +70,10 @@ export interface FileSystemConfig extends ConnectConfig {
   _location?: ConfigLocation;
   /* Internal property keeping track of where this config comes from (including merges) */
   _locations: ConfigLocation[];
+  /* Debug port to attach */
+  debugPort?: number;
+  /* Task to run before debug session starts. SSH command: e.g. `/opt/vistec/python/bin/python -m ptvsd --host ${config.host} --port ${config.debugPort} --wait ${file}` */
+  debugPreLaunch?: string;
 }
 
 export function invalidConfigName(name: string) {

--- a/src/fileSystemConfig.ts
+++ b/src/fileSystemConfig.ts
@@ -108,6 +108,8 @@ export interface FileSystemConfig extends ConnectConfig {
   debugPort?: number;
   /** Task to run before debug session starts. SSH command: e.g. `/opt/vistec/python/bin/python -m ptvsd --host ${config.host} --port ${config.debugPort} --wait ${file}` */
   debugPreLaunch?: string;
+  /** Commands that run right after the terminal opens, e.g. 'sd [.-.gs.dcl]' */
+  customTerminalCommands?: string[];
 }
 
 export function invalidConfigName(name: string) {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -5,6 +5,7 @@ import { getConfig, getConfigs, loadConfigs, loadConfigsRaw, UPDATE_LISTENERS } 
 import { FileSystemConfig, getGroups } from './fileSystemConfig';
 import * as Logging from './logging';
 import { catchingPromise, toPromise } from './toPromise';
+import { openTerminal } from './connectTerminal';
 import { Navigation } from './webviewMessages';
 
 type SSHFileSystem = import('./sshFileSystem').SSHFileSystem;
@@ -356,5 +357,10 @@ export class Manager implements vscode.TreeDataProvider<string | FileSystemConfi
   public async openSettings(navigation?: Navigation) {
     const { open, navigate } = await import('./settings');
     return navigation ? navigate(navigation) : open();
+  }
+  public commandConnectTerminal(target: string | FileSystemConfig) {
+    if (typeof target === 'object') target = target.name;
+    Logging.info(`Command received to open terminal ${target}`);
+    openTerminal(target);
   }
 }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -101,6 +101,24 @@ export class Manager implements vscode.TreeDataProvider<string | FileSystemConfi
       if (!config) {
         throw new Error(`A SSH filesystem with the name '${name}' doesn't exist`);
       }
+
+      // auto detect OpenVMS with root path prefix
+      if (config.openvms === undefined) {
+        if (config.root && config.root.startsWith('/DISK$'))
+          config.openvms = true;
+      }
+
+      // hides default OpenVMS settings
+      if (config.openvms) {
+        config.algorithms = config.algorithms || {};
+        config.algorithms.kex = config.algorithms.kex || [];
+        config.algorithms.kex.push("diffie-hellman-group1-sha1");
+        config.algorithms.cipher = config.algorithms.cipher || [];
+        config.algorithms.cipher.push("aes256-cbc");
+        config.algorithms.serverHostKey = config.algorithms.serverHostKey || [];
+        config.algorithms.serverHostKey.push("ssh-dss");
+      } 
+
       const client = await createSSH(config);
       if (!client) return reject(null);
       let root = config!.root || '/';

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -146,6 +146,89 @@ export class Manager implements vscode.FileSystemProvider, vscode.TreeDataProvid
         }
         root = root.replace(/^~/, home.replace(/\/$/, ''));
       }
+      
+      vscode.debug.registerDebugConfigurationProvider("*", {
+        resolveDebugConfiguration(folder: vscode.WorkspaceFolder, debugConfig: vscode.DebugConfiguration) {
+
+          if ((folder.uri.scheme === 'ssh') && config) {
+            debugConfig['request'] = 'attach';
+            debugConfig['pathMappings'] = [];
+            debugConfig['pathMappings'].push({ 'localRoot': 'ssh://' + config.name, 'remoteRoot': config.root });
+
+            if (config.debugPort) {
+              if (debugConfig['port'] && (debugConfig['port'] !== config.port))
+                Logging.warning(`Invalid port in 'launch.json' working on '${config.name}'`);
+              debugConfig['port'] = config.debugPort;
+
+              if (debugConfig['host'] && (debugConfig['host'] !== config.host))
+                Logging.warning(`Invalid host in 'launch.json' working on '${config.name}'`);
+              debugConfig['host'] = config.host;
+            }
+
+            if (debugConfig['port'] === undefined)
+              Logging.error(`Missing property "debugPort" for remote debugging on '${config.name}'`);
+
+            let workspaceFolder = root;
+            let file = "${file}"; // default to get error message to open an editor
+            if (vscode.window.activeTextEditor)
+              file = root + vscode.window.activeTextEditor.document.uri.path; // '${file}' can not be resolved per default              
+            if (debugConfig['program'])
+              debugConfig['program'] = eval('`' + debugConfig['program'] + '`'); // resolve ${file}, ${workspaceFolder}   
+            else
+              debugConfig['program'] = file;  
+          }                      
+          return debugConfig;
+        }
+      });
+
+     
+      vscode.debug.registerDebugAdapterTrackerFactory('*', {
+        createDebugAdapterTracker(session: vscode.DebugSession) {
+          if (config && config.debugPreLaunch) {
+            return {
+              onWillStartSession: () => {                
+                if (config && config.debugPreLaunch) {                 
+                  const file = session.configuration['program'];                  
+                  const command = eval('`' + config.debugPreLaunch + '`'); // resolve ${file} and config.              
+                  
+                  new Promise((resolve, reject) => {
+                    Logging.info(`Start preLaunch Task for remote debugging: ${command}`);
+                    client.exec(command, (err, stream) => {
+                      if (err) return reject(err);
+                      stream.stderr.on('data', (d) => {
+                        Logging.error(`Stderr from remote debugging: ${d}`);
+                      })
+                      stream.on('data', (d) => {
+                        Logging.debug(`Stdout from remote debugging: ${d}`);
+                      })
+                      stream.on('error', reject);
+                      stream.on('close', (exitCode, signal) => {
+                        if (exitCode || signal) {
+                          return reject(new Error("error listing directory"));
+                        }
+                        resolve();
+                      });
+                    });
+                  });
+            }}};
+          }}
+      });
+
+      vscode.debug.registerDebugAdapterTrackerFactory('*', {
+        createDebugAdapterTracker(session: vscode.DebugSession) {
+          if (session.configuration['dapTrace']) {          
+            return {
+              onWillStartSession: () => console.log(`start: ${session.id}`),                  
+              onWillReceiveMessage: m => console.log(`===> ${JSON.stringify(m, undefined, 2)}`),
+              onDidSendMessage: m => console.log(`<=== ${JSON.stringify(m, undefined, 2)}`),
+              onWillStopSession: () => console.log(`stop: ${session.id}`),
+              onError: err => console.log(`error: ${err}`),
+              onExit: (code, signal) => console.log(`exit: ${code}`)
+            };
+          }
+        }
+      });
+
       const sftp = await getSFTP(client, config);
       const fs = new SSHFileSystem(name, sftp, root, config!);
       Logging.info(`Created SSHFileSystem for ${name}, reading root directory...`);

--- a/webview/src/ConfigEditor/fields.tsx
+++ b/webview/src/ConfigEditor/fields.tsx
@@ -100,5 +100,18 @@ export function passphrase(config: FileSystemConfig, onChange: FSCChanged<'passp
   return <FieldDropdownWithInput key="passphrase" label="Passphrase" {...{ value, values, description }} onChange={callback} optional={true} />
 }
 
+export function debugPort(config: FileSystemConfig, onChange: FSCChanged<'debugPort'>): React.ReactElement {
+  const callback = (value?: number) => onChange('debugPort', value);
+  const description = 'Debug port to attach';
+  return <FieldNumber key="debugPort" label="Debug port" value={config.debugPort} onChange={callback} optional={true} description={description} />  
+}
+
+export function debugPreLaunch(config: FileSystemConfig, onChange: FSCChanged<'debugPreLaunch'>): React.ReactElement {
+  const callback = (value?: string) => onChange('debugPreLaunch', value);
+  const description = 'Task to run before debug session starts. SSH command: e.g. `/opt/vistec/python/bin/python -m ptvsd --host ${config.host} --port ${config.debugPort} --wait ${file}`';
+  return <FieldString key="debugPreLaunch" label="Debug Launch" value={config.debugPreLaunch} onChange={callback} optional={true} description={description} />
+}
+
+
 type FieldFactory = (config: FileSystemConfig, onChange: FSCChanged) => React.ReactElement;
-export const FIELDS: FieldFactory[] = [name, merge, label, putty, host, port, root, agent, username, password, privateKeyPath, passphrase];
+export const FIELDS: FieldFactory[] = [name, merge, label, putty, host, port, root, agent, username, password, privateKeyPath, passphrase, debugPort, debugPreLaunch];

--- a/webview/src/ConfigEditor/fields.tsx
+++ b/webview/src/ConfigEditor/fields.tsx
@@ -71,14 +71,6 @@ export function root(config: FileSystemConfig, onChange: FSCChanged<'root'>): Re
   return <FieldString key="root" label="Root" value={config.root} onChange={callback} optional={true} validator={pathValidator} description={description} />
 }
 
-export function openvms(config: FileSystemConfig, onChange: FSCChanged<'openvms'>): React.ReactElement {
-  const callback = (newValue: string) => onChange('openvms', newValue === 'Yes' || undefined);
-  const description = 'Filesystem is on OpenVSM with versioning, Set if not init and root starts with "/DISK$"';
-  const values = ['Yes', 'No'];
-  const value = config.openvms ? 'Yes' : 'No';
-  return <FieldDropdown key="openvms" label="OpenVMS" {...{ value, values, description }} onChange={callback} />
-}
-
 export function agent(config: FileSystemConfig, onChange: FSCChanged<'agent'>): React.ReactElement {
   const callback = (newValue: string) => onChange('agent', newValue === 'pageant' ? (true as any) : newValue);
   const description = `Path to ssh-agent's UNIX socket for ssh-agent-based user authentication. Supports 'pageant' for PuTTY's Pagent, and environment variables, e.g. $SSH_AUTH_SOCK`;
@@ -129,9 +121,16 @@ export function debugPreLaunch(config: FileSystemConfig, onChange: FSCChanged<'d
   return <FieldString key="debugPreLaunch" label="Remote Debugging PreLaunch" value={config.debugPreLaunch} onChange={callback} optional={true} description={description} />
 }
 
+/* TODO: FieldType array of string ??, with add, delete and edit!
+export function customTerminalCommands(config: FileSystemConfig, onChange: FSCChanged<'customTerminalCommands'>): React.ReactElement {
+  const callback = (value?: string[]) => onChange('customTerminalCommands', value);
+  const description =  'Commands that run right after the terminal opens, e.g. `sd [.-.gs.dcl]`';
+  return <FieldStringArray key="customTerminalCommands" label="Terminal Commands" value={config.customTerminalCommands} onChange={callback} optional={true} description={description} /> 
+}*/
+
 export type FieldFactory = (config: FileSystemConfig, onChange: FSCChanged, onChangeMultiple: FSCChangedMultiple) => React.ReactElement | null;
 export const FIELDS: FieldFactory[] = [
   name, merge, label, group, putty, host, port,
-  root, openvms, agent, username, password, privateKeyPath, passphrase,
+  root, agent, username, password, privateKeyPath, passphrase,
   PROXY_FIELD,
   debugPort, debugPreLaunch];

--- a/webview/src/ConfigEditor/fields.tsx
+++ b/webview/src/ConfigEditor/fields.tsx
@@ -112,13 +112,13 @@ export function passphrase(config: FileSystemConfig, onChange: FSCChanged<'passp
 export function debugPort(config: FileSystemConfig, onChange: FSCChanged<'debugPort'>): React.ReactElement {
   const callback = (value?: number) => onChange('debugPort', value);
   const description = 'Debug port to attach';
-  return <FieldNumber key="debugPort" label="Debug port" value={config.debugPort} onChange={callback} optional={true} description={description} />  
+  return <FieldNumber key="debugPort" label="Remote Debugging Port" value={config.debugPort} onChange={callback} optional={true} description={description} />  
 }
 
 export function debugPreLaunch(config: FileSystemConfig, onChange: FSCChanged<'debugPreLaunch'>): React.ReactElement {
   const callback = (value?: string) => onChange('debugPreLaunch', value);
   const description = 'Task to run before debug session starts. SSH command: e.g. `/opt/vistec/python/bin/python -m ptvsd --host ${config.host} --port ${config.debugPort} --wait ${file}`';
-  return <FieldString key="debugPreLaunch" label="Debug Launch" value={config.debugPreLaunch} onChange={callback} optional={true} description={description} />
+  return <FieldString key="debugPreLaunch" label="Remote Debugging PreLaunch" value={config.debugPreLaunch} onChange={callback} optional={true} description={description} />
 }
 
 export type FieldFactory = (config: FileSystemConfig, onChange: FSCChanged, onChangeMultiple: FSCChangedMultiple) => React.ReactElement | null;

--- a/webview/src/ConfigEditor/fields.tsx
+++ b/webview/src/ConfigEditor/fields.tsx
@@ -71,6 +71,14 @@ export function root(config: FileSystemConfig, onChange: FSCChanged<'root'>): Re
   return <FieldString key="root" label="Root" value={config.root} onChange={callback} optional={true} validator={pathValidator} description={description} />
 }
 
+export function openvms(config: FileSystemConfig, onChange: FSCChanged<'openvms'>): React.ReactElement {
+  const callback = (newValue: string) => onChange('openvms', newValue === 'Yes' || undefined);
+  const description = 'Filesystem is on OpenVSM with versioning, Set if not init and root starts with "/DISK$"';
+  const values = ['Yes', 'No'];
+  const value = config.openvms ? 'Yes' : 'No';
+  return <FieldDropdown key="openvms" label="OpenVMS" {...{ value, values, description }} onChange={callback} />
+}
+
 export function agent(config: FileSystemConfig, onChange: FSCChanged<'agent'>): React.ReactElement {
   const callback = (newValue: string) => onChange('agent', newValue === 'pageant' ? (true as any) : newValue);
   const description = `Path to ssh-agent's UNIX socket for ssh-agent-based user authentication. Supports 'pageant' for PuTTY's Pagent, and environment variables, e.g. $SSH_AUTH_SOCK`;
@@ -124,6 +132,6 @@ export function debugPreLaunch(config: FileSystemConfig, onChange: FSCChanged<'d
 export type FieldFactory = (config: FileSystemConfig, onChange: FSCChanged, onChangeMultiple: FSCChangedMultiple) => React.ReactElement | null;
 export const FIELDS: FieldFactory[] = [
   name, merge, label, group, putty, host, port,
-  root, agent, username, password, privateKeyPath, passphrase,
+  root, openvms, agent, username, password, privateKeyPath, passphrase,
   PROXY_FIELD,
   debugPort, debugPreLaunch];

--- a/webview/src/types/fileSystemConfig.ts
+++ b/webview/src/types/fileSystemConfig.ts
@@ -43,7 +43,7 @@ export function groupByLocation(configs: FileSystemConfig[]): Array<[ConfigLocat
 }
 
 export interface FileSystemConfig extends ConnectConfig {
-  /* Name of the config. Can only exists of lowercase alphanumeric characters, slashes and any of these: _.+-@ */
+  /* Name of the config. Can only exists of lowercase alphanumeric characters, slashes and any of these: _.+-@ */  
   name: string;
   /* Optional label to display in some UI places (e.g. popups) */
   label?: string;
@@ -69,6 +69,10 @@ export interface FileSystemConfig extends ConnectConfig {
   _location?: ConfigLocation;
   /* Internal property keeping track of where this config comes from (including merges) */
   _locations: ConfigLocation[];
+  /* Debug port to attach */
+  debugPort?: number;
+  /* Task to run before debug session starts. SSH command: e.g. `/opt/vistec/python/bin/python -m ptvsd --host ${config.host} --port ${config.debugPort} --wait ${file}` */
+  debugPreLaunch?: string;
 }
 
 export function invalidConfigName(name: string) {

--- a/webview/src/types/fileSystemConfig.ts
+++ b/webview/src/types/fileSystemConfig.ts
@@ -102,9 +102,9 @@ export interface FileSystemConfig extends ConnectConfig {
   _location?: ConfigLocation;
   /** Internal property keeping track of where this config comes from (including merges) */
   _locations: ConfigLocation[];
-  /* Debug port to attach */
+  /** Debug port to attach */
   debugPort?: number;
-  /* Task to run before debug session starts. SSH command: e.g. `/opt/vistec/python/bin/python -m ptvsd --host ${config.host} --port ${config.debugPort} --wait ${file}` */
+  /** Task to run before debug session starts. SSH command: e.g. `/opt/vistec/python/bin/python -m ptvsd --host ${config.host} --port ${config.debugPort} --wait ${file}` */
   debugPreLaunch?: string;
 }
 

--- a/webview/src/types/fileSystemConfig.ts
+++ b/webview/src/types/fileSystemConfig.ts
@@ -84,6 +84,8 @@ export interface FileSystemConfig extends ConnectConfig {
   merge?: boolean;
   /** Path on the remote server where the root path in vscode should point to. Defaults to / */
   root?: string;
+  /** Filesystem is on OpenVSM with versioning, Set if not init and root starts with '/DISK$' */
+  openvms?: boolean;
   /** A name of a PuTTY session, or `true` to find the PuTTY session from the host address  */
   putty?: string | boolean;
   /** Optional object defining a proxy to use */

--- a/webview/src/types/fileSystemConfig.ts
+++ b/webview/src/types/fileSystemConfig.ts
@@ -108,6 +108,8 @@ export interface FileSystemConfig extends ConnectConfig {
   debugPort?: number;
   /** Task to run before debug session starts. SSH command: e.g. `/opt/vistec/python/bin/python -m ptvsd --host ${config.host} --port ${config.debugPort} --wait ${file}` */
   debugPreLaunch?: string;
+  /** Commands that run right after the terminal opens, e.g. 'sd [.-.gs.dcl]' */
+  customTerminalCommands?: string[];
 }
 
 export function invalidConfigName(name: string) {


### PR DESCRIPTION
Unfortunately you are  not right, if you write in #77 that existing debug features can be used. A lot of variables #https://code.visualstudio.com/docs/editor/variables-reference not resolved, e.g. '${file}'. The 'pathMappings' in launch.json to set breakpoints has to be defined specifically for the extension! 

From a practical point of view, with your great extenstion remote working is like local working. But to launch means to distinguish. So i  have to manage a launch, for every SSH-FS configuration, that define host and root, where actually only a debugport as new information is added. The worst thing is that I have to manage a little extra locally! 

I add two config properties, patch SSH-launch's to attach and define pathmapping from SSH-FS root setting. You can work with a local launch, too. But there is no need.
