### PR TITLE
SSH terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![Logo](./resources/Logo.png)
 
-[![GitHub package version](./media/github.png)](https://github.com/SchoofsKelvin/vscode-sshfs) 
+[![GitHub package version](./media/github.png)](https://github.com/SchoofsKelvin/vscode-sshfs)
 [![Visual Studio Marketplace](https://vsmarketplacebadge.apphb.com/version-short/Kelvin.vscode-sshfs.svg)](https://marketplace.visualstudio.com/items?itemName=Kelvin.vscode-sshfs)
  [![Donate](./media/paypal.png)](https://www.paypal.me/KSchoofs)
 
@@ -19,6 +19,7 @@ This extension makes use of the new FileSystemProvider, added in version 1.23.0 
 * Easily create configurations that reference a PuTTY session/configuration
 * Have multiple SSH (and regular) workspace folders at once
 * Make use of SOCKS 4/5 and HTTP proxies and connection hopping
+* Easily open a SSH Terminal from VSCode
 
 ## Usage
 Use the command `SSH FS: Create a SSH FS configuration`, or open the Settings UI using the `SSH FS: Open settings and edit configurations` and click Add:
@@ -36,4 +37,3 @@ To connect, either rightclick the name in the Explorer tab, or use the command p
 This will add a Workspace folder linked to a SSH (SFTP) session:
 
 ![Workspace folder added](./media/screenshot-explorer.png)
-

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "onCommand:sshfs.disconnect",
         "onCommand:sshfs.configure",
         "onCommand:sshfs.reload",
-        "onCommand:sshfs.settings"
+        "onCommand:sshfs.settings",
+        "onCommand:sshfs.terminal"
     ],
     "main": "./dist/extension.js",
     "author": {
@@ -81,6 +82,11 @@
                 "command": "sshfs.settings",
                 "title": "Open settings and edit configurations",
                 "category": "SSH FS"
+            },
+            {
+                "command": "sshfs.terminal",
+                "title": "Open SSH Terminal",
+                "category": "SSH FS"
             }
         ],
         "menus": {
@@ -112,6 +118,10 @@
                 {
                     "command": "sshfs.settings",
                     "group": "SSH FS@7"
+                },
+                {
+                    "command": "sshfs.terminal",
+                    "group": "SSH FS@8"
                 }
             ],
             "view/item/context": [
@@ -144,6 +154,11 @@
                     "command": "sshfs.settings",
                     "when": "view == 'sshfs-configs' && !viewItem",
                     "group": "SSH FS@6"
+                },
+                {
+                    "command": "sshfs.terminal",
+                    "when": "view == 'sshfs-configs' && viewItem",
+                    "group": "SSH FS@7"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
                 },
                 {
                     "command": "sshfs.terminal",
-                    "when": "view == 'sshfs-configs' && viewItem",
+                    "when": "view == 'sshfs-configs' && viewItem == active",
                     "group": "SSH FS@7"
                 }
             ]

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -7,6 +7,7 @@ import { getConfigs } from './config';
 import { FileSystemConfig } from './fileSystemConfig';
 import * as Logging from './logging';
 import { toPromise } from './toPromise';
+import { openTerminal } from './terminal';
 
 // tslint:disable-next-line:variable-name
 const SFTPWrapper = require('ssh2/lib/SFTPWrapper') as (new (stream: SFTPStream) => SFTPWrapperReal);
@@ -209,6 +210,14 @@ export async function createSSH(config: FileSystemConfig, sock?: NodeJS.Readable
     } catch (e) {
       reject(e);
     }
+    try {
+        Logging.info(`[${config.name}] Opening SSH terminal`);
+        openTerminal(config);
+    } catch (e) {
+        reject(e);
+    }
+
+
   });
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,4 +69,7 @@ export function activate(context: vscode.ExtensionContext) {
   registerCommand('sshfs.configure', (name?: string) => pickAndClick(manager.commandConfigure, name));
 
   registerCommand('sshfs.reload', loadConfigs);
+
+  registerCommand('sshfs.terminal', (name?: string) => pickAndClick(manager.commandTerminal, name, false));
+
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,6 +70,6 @@ export function activate(context: vscode.ExtensionContext) {
 
   registerCommand('sshfs.reload', loadConfigs);
 
-  registerCommand('sshfs.terminal', (name?: string) => pickAndClick(manager.commandTerminal, name, false));
+  registerCommand('sshfs.terminal', (name?: string) => pickAndClick(manager.commandTerminal, name, true));
 
 }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -6,6 +6,7 @@ import { FileSystemConfig, getGroups } from './fileSystemConfig';
 import * as Logging from './logging';
 import { catchingPromise, toPromise } from './toPromise';
 import { Navigation } from './webviewMessages';
+import { openTerminal } from './terminal';
 
 type SSHFileSystem = import('./sshFileSystem').SSHFileSystem;
 
@@ -238,32 +239,16 @@ export class Manager implements vscode.TreeDataProvider<string | FileSystemConfi
     }
     vscode.workspace.updateWorkspaceFolders(folders ? folders.length : 0, 0, { uri: vscode.Uri.parse(`ssh://${target}/`), name: `SSH FS - ${target}` });
     this.onDidChangeTreeDataEmitter.fire();
-    this.commandTerminal(target);
+
   }
   public commandTerminal(target: string | FileSystemConfig) {
     //const config = typeof target === 'object' ? target : undefined;
     if (typeof target === 'object') target = target.name;
-    const config = getConfig(target);
-    Logging.info(`Command received to open terminal to ${target}`);
-
-    let sshcmd = `${config?.username}@${config?.host}`;
-    if (config?.port) { sshcmd += `-p ${config?.port}` }
-    Logging.debug(`\Opening terminal to ${sshcmd}`);
-    if (config?.root) {
-        // If you don't use -t then no prompt will appear.
-        // If you don't add ; bash then the connection will
-        // get closed and return control to your local machine
-        sshcmd += ` -t "cd ${config?.root}; exec \\$SHELL" `;
+    let config = getConfig(target);
+    if (!config) {
+        throw new Error(`A SSH filesystem with the name '${target}' doesn't exist`);
     }
-    //if (this.getActive().find(fs => fs.name === target)) {
-    const folders = vscode.workspace.workspaceFolders;
-    const folder = folders && folders.find(f => f.uri.scheme === 'ssh' && f.uri.authority === target);
-    if (folder) {
-      let sshterm = vscode.window.createTerminal(`SSH Terminal - ${target}`);
-      sshterm.sendText('ssh ' + sshcmd);
-     // sshterm.sendText(`${config?.password}`);
-      sshterm.show();
-    }
+    openTerminal(config);
   }
   public async commandConfigure(target: string | FileSystemConfig) {
     Logging.info(`Command received to configure ${typeof target === 'string' ? target : target.name}`);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+import * as Logging from './logging';
+//import { getConfig, getConfigs, loadConfigs } from './config';
+import { calculateActualConfig } from './connect';
+import { FileSystemConfig } from './fileSystemConfig';
+
+//export async function openTerminal(name: string) {
+export async function openTerminal(config: FileSystemConfig) {
+    Logging.info(`Command received to open terminal to ${config.name}`);
+    let connectionMethod = "password";
+    let ssh = 'ssh ' + config.host + ' -l ' + config.username;
+    if (config.port !== 22 && config.port !== undefined && config.port) ssh += ' -p ' + config.port;
+    Logging.debug(`\Opening terminal to ${ssh}`);
+    // Add to be private key path because of vulnerability leak we can't pass private key by command
+    if (config.privateKeyPath !== undefined && config.privateKeyPath) {
+        connectionMethod = "privateKey";
+        ssh += ' -i ' + config.privateKeyPath;
+    }
+    if (config.agent !== undefined && config.agent) connectionMethod = "agent";
+    const folders = vscode.workspace.workspaceFolders;
+    const folder = folders && folders.find(f => f.uri.scheme === 'ssh' && f.uri.authority === config.name);
+    if (folder) {
+        var terminal = vscode.window.createTerminal(`SSH Terminal - ${config.name}`);
+        terminal.sendText(ssh);
+        if (config.password !== undefined && config.password && connectionMethod === "password") {
+            terminal.sendText(config.password);
+        }
+        if (config.root !== undefined && config.root) terminal.sendText('cd ' + config.root);
+        else terminal.sendText('cd $HOME');
+
+        terminal.show();
+    }
+}

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,7 +1,5 @@
 import * as vscode from 'vscode';
 import * as Logging from './logging';
-//import { getConfig, getConfigs, loadConfigs } from './config';
-import { calculateActualConfig } from './connect';
 import { FileSystemConfig } from './fileSystemConfig';
 
 //export async function openTerminal(name: string) {


### PR DESCRIPTION
When working on remote computers via SSHFS, you will need a terminal from time to time. However, the use of the [Terminal SSH](https://marketplace.visualstudio.com/items?itemName=sailhenz.terminal-ssh) extension leads to redundancies. 

With the extension [Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) i miss the possibility to mount the folders as workspace. On the other hand, the [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension is too much for me.

This extension is better suited for my purposes, so I added the missing SSH terminal functionality based on Issue #26 and Pull Request #61 of @nunure, so that when connecting as a workspace, an associated terminal is opened.

I use Windows (#shameonme:) and have the [OpenSSH client](https://docs.microsoft.com/de-de/windows-server/administration/openssh/openssh_install_firstuse) installed.