### PR TITLE
Simplify NewConfig description

### DIFF
--- a/webview/src/NewConfig.tsx
+++ b/webview/src/NewConfig.tsx
@@ -30,7 +30,7 @@ class NewConfig extends React.Component<StateProps & DispatchProps> {
                 <h2>Create new configuration</h2>
                 <FieldString
                     label="Name"
-                    description="Name of the config. Can only exists of lowercase alphanumeric characters, slashes and any of these: _.+-@"
+                    description="Name of the config. Accepted characters: [0-9a-z_.+-@]"
                     value={name}
                     validator={invalidConfigName}
                     onChange={setName}


### PR DESCRIPTION
The current description is in my opinion longer than it should be. I propose compiling the accepted values into a list rather than describing them through words.