### PR TITLE
Update workflows to use ubuntu-22.04 and updated dependencies (closes #372)

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -6,71 +6,51 @@ on:
     tags: ['**']
     branches:
       - '*'
+      - 'issue/**'
       - 'feature/**'
       - 'release/**'
   pull_request:
     types: [opened, synchronize]
     branches:
       - '*'
+      - 'issue/**'
       - 'feature/**'
       - 'release/**'
   workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     name: Build and package
     timeout-minutes: 10 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Event Utilities
-      uses: SchoofsKelvin/event-utilities@v1
+      uses: SchoofsKelvin/event-utilities@v1.1.0
       id: utils
       with:
         artifact_prefix: "vscode-sshfs"
         artifact_extension: "vsix"
-    - name: Use Node.js 14.x
-      uses: actions/setup-node@v1
+    - name: Use Node.js 18
+      uses: actions/setup-node@v3
       with:
-        node-version: 14.x
-    - name: Get Yarn cache directory
-      id: yarn-cache
-      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-    - name: Yarn cache
-      uses: actions/cache@v2.1.4
-      with:
-        path: ${{ steps.yarn-cache.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+        node-version: 18
+        cache: yarn
+        cache-dependency-path: .yarn/yarn.lock
     - name: Install dependencies
       run: yarn --immutable
     - name: Build extension
       run: yarn vsce package -o ${{ steps.utils.outputs.artifact_name }} --yarn --no-dependencies
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v2.2.1
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.utils.outputs.artifact_name }}
         path: ${{ steps.utils.outputs.artifact_name }}
         if-no-files-found: error
-    - name: Create release
-      id: create_release
+    - name: Create release with artifact
       if: ${{ success() && steps.utils.outputs.tag_version }}
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ steps.utils.outputs.tag_version }}
+        name: Release ${{ steps.utils.outputs.tag_version }}
         draft: true
-    - name: Upload release asset
-      id: upload_release_asset
-      if: ${{ success() && steps.utils.outputs.tag_version }}
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ steps.utils.outputs.artifact_name }}
-        asset_name: ${{ steps.utils.outputs.artifact_name }}
-        asset_content_type: application/vsix
+        files: ${{ steps.utils.outputs.artifact_name }}

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -15,11 +15,10 @@ jobs:
     - name: Validate extension file
       run: unzip -f extension.vsix extension/package.json
     - name: Publish to Open VSX Registry
-      uses: HaaLeo/publish-vscode-extension@v0
+      uses: HaaLeo/publish-vscode-extension@v1
       with:
         pat: ${{ secrets.OPEN_VSX_TOKEN }}
         extensionFile: extension.vsix
-        packagePath: ''
   vs:
     name: "Visual Studio Marketplace"
     if: endsWith(github.event.release.assets[0].name, '.vsix')
@@ -30,9 +29,8 @@ jobs:
     - name: Validate extension file
       run: unzip -f extension.vsix extension/package.json
     - name: Publish to Visual Studio Marketplace
-      uses: HaaLeo/publish-vscode-extension@v0
+      uses: HaaLeo/publish-vscode-extension@v1
       with:
         pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
         registryUrl: https://marketplace.visualstudio.com
         extensionFile: extension.vsix
-        packagePath: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@
   - Upgrade a bunch of plugins and other dependencies
 - Fix linter warnings in Markdown files and remove default webview/README.md
 - Fix build workflow to account for incompatibility from using a new `vsce` version
+- Updated the GitHub workflows (#372)
+  - Added `issue/**` to the `push` and `pull_request` triggers to automatically build on these branches
+  - The build workflow upgraded from `ubuntu-18.04` to `ubuntu-22.04`
+  - All actions are upgraded to a more recent version
+  - Caching of Yarn dependencies is now handled by `actions/setup-node`
+  - Migrated from `actions/create-release` and `actions/upload-release-asset` to `softprops/action-gh-release`
 
 ## v1.25.0 (2022-06-01)
 


### PR DESCRIPTION
Needed to update the workflow in several ways to prevent it from breaking soon:

- Switched from `ubuntu-18.04` to `ubuntu-22.04`
  - This fixes actions/runner-images#6002 which would otherwise break the workflows next week
- Upgraded `actions/checkout@v2` to `actions/checkout@v3`
- Upgraded `actions/setup-node@v1` to `actions/setup-node@v3`
  - This now also replaces the `actions/cache@v2.1.4` step along with the "Get Yarn cache directory" step
- Indirectly upgraded `SchoofsKelvin/event-utilities@v1` (see [SchoofsKelvin/event-utilities@v1.1.0](https://github.com/SchoofsKelvin/event-utilities/releases/tag/v1.1.0))
- Migrated from `actions/upload-artifact@v2.2.1` and `actions/create-release@v1` to `softprops/action-gh-release@v1`
- Upgraded `HaaLeo/publish-vscode-extension@v0` to `HaaLeo/publish-vscode-extension@v1`

This merge request fixes  #372.